### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-
+# ignore OSx Filesystem-Infos
 .DS_Store
+
+# ignore SolidWorks temporary files
+~$*.SLDPRT
+~$*.SLDASM


### PR DESCRIPTION
Damit werden dann keine Temp-Dateien von Solidworks mehr ins Git-Repro aufgenommen.